### PR TITLE
selectAll for single table

### DIFF
--- a/core/src/main/scala/datas.scala
+++ b/core/src/main/scala/datas.scala
@@ -156,7 +156,9 @@ object datas {
     }
   }
 
-  final case class Column(name: String) extends AnyVal
+  final case class Column(name: String) extends AnyVal {
+    def showQuoted: String = "\"" + name + "\""
+  }
 
   sealed trait ReferenceData[Type] extends Product with Serializable
 
@@ -168,7 +170,7 @@ object datas {
     private[datas] def compileData[Type](getType: Get[Type]): ReferenceData[Type] => TypedFragment[Type] = {
       case ReferenceData.Column(column, scope) =>
         val scopeString = scope.foldMap(_ + ".")
-        TypedFragment(Fragment.const(scopeString + "\"" + column.name + "\""), getType)
+        TypedFragment(Fragment.const(scopeString + column.showQuoted), getType)
       case l: ReferenceData.Lift[a] =>
         implicit val param: Param[a HCons HNil] = l.into
         val _ = param //to make scalac happy

--- a/core/src/main/scala/datas.scala
+++ b/core/src/main/scala/datas.scala
@@ -16,6 +16,11 @@ import cats.FlatMap
 import cats.data.OptionT
 
 object datas {
+
+  trait SequenceK[Alg[_[_]]] {
+    def sequence[F[_]: Apply, G[_]](alg: Alg[λ[a => F[G[a]]]]): F[Alg[G]]
+  }
+
   type ColumnList = List[Column]
 
   object schemas {
@@ -277,7 +282,7 @@ object datas {
     def mapBoth[T2](f: Type => T2): CompiledReference[T2] = ermap(_.bimap(_.map(f), _.map(f)))
   }
 
-  //A *->*->* -kinded option transformer
+  //A ((*->*)->*)->* (or so)-kinded option transformer
   case class OptionTK[F[_[_]], G[_]](underlying: F[OptionT[G, ?]])
 
   object OptionTK {

--- a/core/src/main/scala/datas.scala
+++ b/core/src/main/scala/datas.scala
@@ -1,3 +1,5 @@
+package datas
+
 import cats.implicits._
 import doobie.util.fragment.Fragment
 import doobie._
@@ -10,316 +12,270 @@ import cats.tagless.implicits._
 import cats.Apply
 import shapeless.HNil
 import shapeless.{:: => HCons}
-import cats.mtl.MonadState
 import cats.mtl.instances.all._
 import cats.FlatMap
 import cats.data.OptionT
-import cats.arrow.FunctionK
+import datas.tagless.TraverseK
+import datas.tagless.Tuple2KK
+import datas.tagless.OptionTK
 
-object datas {
+//todo naming
+sealed trait ColumnK[A] extends Product with Serializable {
+  def optional: ColumnK[Option[A]] = ColumnK.Optional(this)
+}
 
-  trait TraverseK[Alg[_[_]]] extends FunctorK[Alg] {
+object ColumnK {
+  final case class Named[A](name: Column, get: Get[A]) extends ColumnK[A]
+  final case class Optional[A](underlying: ColumnK[A]) extends ColumnK[Option[A]]
+}
 
-    def traverseK[F[_], G[_]: Apply, H[_]](alg: Alg[F])(fk: F ~> λ[a => G[H[a]]]): G[Alg[H]]
+object schemas {
+  type ST[X] = State[Chain[Column], X]
 
-    def sequenceK[F[_]: Apply, G[_]](alg: Alg[λ[a => F[G[a]]]]): F[Alg[G]] =
-      traverseK[λ[a => F[G[a]]], F, G](alg)(FunctionK.id[λ[a => F[G[a]]]])
+  private type STRef[X] = ST[Reference[X]]
 
-    def mapK[F[_], G[_]](af: Alg[F])(fk: F ~> G): Alg[G] = traverseK[F, cats.Id, G](af)(fk)
+  private val columnToStRef: ColumnK ~> STRef = λ[ColumnK ~> STRef] {
+    case ColumnK.Named(name, get) =>
+      val rf = Reference.Single(ReferenceData.Column(name, none), get)
+      State.modify[Chain[Column]](_.append(name)).as(rf)
 
-    def sequenceKId[F[_]: Apply](alg: Alg[F]): F[Alg[cats.Id]] = sequenceK[F, cats.Id](alg)
+    case ColumnK.Optional(underlying) =>
+      columnToStRef(underlying).map(Reference.liftOption)
   }
 
-  object TraverseK {
-    def apply[Alg[_[_]]](implicit S: TraverseK[Alg]): TraverseK[Alg] = S
-  }
+  def column[Type: Get](name: String): ColumnK[Type] =
+    ColumnK.Named(Column(name), Get[Type])
 
-  //todo naming
-  sealed trait ColumnK[A] extends Product with Serializable {
-    def optional: ColumnK[Option[A]] = ColumnK.Optional(this)
-  }
+  def caseClassSchema[F[_[_]]: TraverseK](name: TableName, columns: F[ColumnK]): TableQuery[F] =
+    TraverseK[F].traverseK(columns)(columnToStRef).runA(Chain.empty).map(schema => TableQuery.FromTable(name, schema, TraverseK[F])).value
+}
 
-  object ColumnK {
-    final case class Named[A](name: Column, get: Get[A]) extends ColumnK[A]
-    final case class Optional[A](underlying: ColumnK[A]) extends ColumnK[Option[A]]
-  }
+final case class TableName(name: String) extends AnyVal {
+  private[datas] def identifierFragment: Fragment = Fragment.const("\"" + name + "\"")
+}
 
-  type ColumnList = Chain[Column]
+sealed trait TableQuery[A[_[_]]] extends Product with Serializable {
 
-  object schemas {
-    type ST[X] = State[Chain[Column], X]
+  def innerJoin[B[_[_]]](
+    another: TableQuery[B]
+  )(
+    onClause: (A[Reference], B[Reference]) => Reference[Boolean]
+  ): TableQuery[JoinKind.Inner[A, B]#Out] =
+    join(another)(_.inner)(onClause)
 
-    private type STRef[X] = ST[Reference[X]]
+  def leftJoin[B[_[_]]: FunctorK](
+    another: TableQuery[B]
+  )(
+    onClause: (A[Reference], B[Reference]) => Reference[Boolean]
+  ): TableQuery[JoinKind.Left[A, B]#Out] =
+    join(another)(_.left)(onClause)
 
-    private val columnToStRef: ColumnK ~> STRef = λ[ColumnK ~> STRef] {
-      case ColumnK.Named(name, get) =>
-        val rf = Reference.Single(ReferenceData.Column(name, none), get)
-        State.modify[ColumnList](_.append(name)).as(rf)
+  private def join[B[_[_]], Joined[_[_]]](
+    another: TableQuery[B]
+  )(
+    kindF: JoinKind.type => JoinKind[A, B, Joined]
+  )(
+    onClause: (A[Reference], B[Reference]) => Reference[Boolean]
+  ): TableQuery[Joined] =
+    TableQuery.Join(this, another, kindF(JoinKind), onClause)
 
-      case ColumnK.Optional(underlying) =>
-        columnToStRef(underlying).map(Reference.liftOption)
-    }
-
-    def column[Type: Get](name: String): ColumnK[Type] =
-      ColumnK.Named(Column(name), Get[Type])
-
-    def caseClassSchema[F[_[_]]: TraverseK](name: TableName, columns: F[ColumnK]): TableQuery[F] =
-      TraverseK[F].traverseK(columns)(columnToStRef).runA(Chain.empty).map(schema => TableQuery.FromTable(name, schema, TraverseK[F])).value
-  }
-
-  final case class TableName(name: String) extends AnyVal {
-    private[datas] def identifierFragment: Fragment = Fragment.const("\"" + name + "\"")
-  }
-
-  private[datas] type IndexState[F[_]] = MonadState[F, Int]
-
-  private[datas] object IndexState {
-    def apply[F[_]](implicit F: IndexState[F]): IndexState[F] = F
-    def getAndInc[F[_]: IndexState: Apply]: F[Int] = IndexState[F].get <* IndexState[F].modify(_ + 1)
-  }
-
-  sealed trait TableQuery[A[_[_]]] extends Product with Serializable {
-
-    def innerJoin[B[_[_]]](
-      another: TableQuery[B]
-    )(
-      onClause: (A[Reference], B[Reference]) => Reference[Boolean]
-    ): TableQuery[JoinKind.Inner[A, B]#Out] =
-      join(another)(_.inner)(onClause)
-
-    def leftJoin[B[_[_]]: FunctorK](
-      another: TableQuery[B]
-    )(
-      onClause: (A[Reference], B[Reference]) => Reference[Boolean]
-    ): TableQuery[JoinKind.Left[A, B]#Out] =
-      join(another)(_.left)(onClause)
-
-    private def join[B[_[_]], Joined[_[_]]](
-      another: TableQuery[B]
-    )(
-      kindF: JoinKind.type => JoinKind[A, B, Joined]
-    )(
-      onClause: (A[Reference], B[Reference]) => Reference[Boolean]
-    ): TableQuery[Joined] =
-      TableQuery.Join(this, another, kindF(JoinKind), onClause)
-
-    def selectAll: Query[A, A[cats.Id]] = select { aref =>
-      this match {
-        case ft: TableQuery.FromTable[A] => ft.traverseK.sequenceKId(aref)
-        case _                           => throw new Exception("select * isn't supported on joins yet")
-      }
-    }
-
-    def select[Queried](selection: A[Reference] => Reference[Queried]): Query[A, Queried] =
-      Query(this, selection, filters = Chain.empty)
-  }
-
-  private[datas] object TableQuery {
-    final case class FromTable[A[_[_]]](table: TableName, lifted: A[Reference], traverseK: TraverseK[A]) extends TableQuery[A]
-
-    final case class Join[A[_[_]], B[_[_]], Joined[_[_]]](
-      left: TableQuery[A],
-      right: TableQuery[B],
-      kind: JoinKind[A, B, Joined],
-      onClause: (A[Reference], B[Reference]) => Reference[Boolean]
-    ) extends TableQuery[Joined]
-
-    /**
-      * Returns: the compiled query base (from + joins) and the scoped references underlying it (passed later to selections and filters).
-      */
-    def compileQuery[A[_[_]], F[_]: IndexState: FlatMap]: TableQuery[A] => F[(Fragment, A[Reference])] = {
-      case t: FromTable[A] =>
-        implicit val functorK: FunctorK[A] = t.traverseK
-        IndexState.getAndInc[F].map { index =>
-          val scope = t.table.name + "_x" + index
-          (
-            t.table.identifierFragment ++ Fragment.const(scope),
-            t.lifted.mapK(setScope(scope))
-          )
-        }
-
-      case j: Join[a, b, k] =>
-        import j._
-        (compileQuery[a, F].apply(left), compileQuery[b, F].apply(right)).mapN {
-          case ((leftFrag, leftCompiledReference), (rightFrag, rightCompiledReference)) =>
-            val thisJoinClause = onClause(leftCompiledReference, rightCompiledReference).compile.frag
-
-            val joinFrag = leftFrag ++ Fragment.const(kind.kind) ++ rightFrag ++ fr"on" ++ thisJoinClause
-
-            (joinFrag, kind.buildJoined(leftCompiledReference, rightCompiledReference))
-        }
-    }
-
-  }
-
-  trait JoinKind[A[_[_]], B[_[_]], Joined[_[_]]] {
-    final type Out[F[_]] = Joined[F]
-
-    def buildJoined(a: A[Reference], b: B[Reference]): Joined[Reference]
-    def kind: String
-  }
-
-  object JoinKind {
-    type Inner[A[_[_]], B[_[_]]] = JoinKind[A, B, Tuple2KK[A, B, ?[_]]]
-    type Left[A[_[_]], B[_[_]]] = JoinKind[A, B, Tuple2KK[A, OptionTK[B, ?[_]], ?[_]]]
-
-    def left[A[_[_]], B[_[_]]: FunctorK]: Left[A, B] = make("left join")((a, b) => Tuple2KK(a, OptionTK.liftK(b)(Reference.liftOptionK)))
-    def inner[A[_[_]], B[_[_]]]: Inner[A, B] = make("inner join")(Tuple2KK.apply _)
-
-    private def make[A[_[_]], B[_[_]], Joined[_[_]]](
-      name: String
-    )(
-      build: (A[Reference], B[Reference]) => Joined[Reference]
-    ): JoinKind[A, B, Joined] = new JoinKind[A, B, Joined] {
-      def buildJoined(a: A[Reference], b: B[Reference]): Joined[Reference] = build(a, b)
-      val kind: String = name
+  def selectAll: Query[A, A[cats.Id]] = select { aref =>
+    this match {
+      case ft: TableQuery.FromTable[A] => ft.traverseK.sequenceKId(aref)
+      case _                           => throw new Exception("select * isn't supported on joins yet")
     }
   }
 
-  private def setScope(scope: String): Reference ~> Reference = Reference.mapData {
-    λ[ReferenceData ~> ReferenceData] {
-      case ReferenceData.Column(n, None) =>
-        ReferenceData.Column(n, Some(scope))
-      case c @ ReferenceData.Column(_, Some(_)) =>
-        //todo this case is impossible, we should have that in the types
-        //or else inline it with the catch-all below
-        c
-      case c => c
-    }
-  }
+  def select[Queried](selection: A[Reference] => Reference[Queried]): Query[A, Queried] =
+    Query(this, selection, filters = Chain.empty)
+}
 
-  final case class Column(name: String) extends AnyVal {
-    def showQuoted: String = "\"" + name + "\""
-  }
+private[datas] object TableQuery {
+  final case class FromTable[A[_[_]]](table: TableName, lifted: A[Reference], traverseK: TraverseK[A]) extends TableQuery[A]
 
-  sealed trait ReferenceData[Type] extends Product with Serializable
+  final case class Join[A[_[_]], B[_[_]], Joined[_[_]]](
+    left: TableQuery[A],
+    right: TableQuery[B],
+    kind: JoinKind[A, B, Joined],
+    onClause: (A[Reference], B[Reference]) => Reference[Boolean]
+  ) extends TableQuery[Joined]
 
-  object ReferenceData {
-    final case class Column[A](col: datas.Column, scope: Option[String]) extends ReferenceData[A]
-    final case class Lift[Type](value: Type, into: Param[Type HCons HNil]) extends ReferenceData[Type]
-    final case class Raw[Type](fragment: Fragment) extends ReferenceData[Type]
-
-    private[datas] def compileData[Type](getType: Get[Type]): ReferenceData[Type] => TypedFragment[Type] = {
-      case ReferenceData.Column(column, scope) =>
-        val scopeString = scope.foldMap(_ + ".")
-        TypedFragment(Fragment.const(scopeString + column.showQuoted), getType)
-      case l: ReferenceData.Lift[a] =>
-        implicit val param: Param[a HCons HNil] = l.into
-        val _ = param //to make scalac happy
-        TypedFragment(fr"${l.value}", getType)
-      case r: ReferenceData.Raw[a] => TypedFragment(r.fragment, getType)
-    }
-
-    final case class TypedFragment[Type](fragment: Fragment, get: Get[Type])
-  }
-
-  sealed trait Reference[Type] extends Product with Serializable {
-
-    private[datas] def compile: CompiledReference[Type] =
-      Reference.compileReference(this)
-  }
-
-  object Reference {
-    final case class Optional[Type](underlying: Reference[Type]) extends Reference[Option[Type]]
-    final case class Single[Type](data: ReferenceData[Type], getType: Get[Type]) extends Reference[Type]
-    final case class Product[L, R](left: Reference[L], right: Reference[R]) extends Reference[(L, R)]
-    final case class Map[A, B](underlying: Reference[A], f: A => B) extends Reference[B]
-
-    val liftOptionK: Reference ~> OptionT[Reference, ?] = λ[Reference ~> OptionT[Reference, ?]](r => OptionT(Optional(r)))
-
-    def liftOption[Type](reference: Reference[Type]): Reference[Option[Type]] = liftOptionK(reference).value
-
-    def lift[Type: Get](value: Type)(implicit param: Param[Type HCons HNil]): Reference[Type] =
-      Reference.Single[Type](ReferenceData.Lift(value, param), Get[Type])
-
-    def mapData(fk: ReferenceData ~> ReferenceData): Reference ~> Reference =
-      λ[Reference ~> Reference] {
-        case Single(data, getType) => Single(fk(data), getType)
-        case Optional(underlying)  => Optional(mapData(fk)(underlying))
-        case Map(underlying, f)    => Map(mapData(fk)(underlying), f)
-        case Product(left, right)  => Product(mapData(fk)(left), mapData(fk)(right))
-      }
-
-    implicit val apply: Apply[Reference] = new Apply[Reference] {
-      override def map[A, B](fa: Reference[A])(f: A => B): Reference[B] = Map(fa, f)
-      override def ap[A, B](ff: Reference[A => B])(fa: Reference[A]): Reference[B] = product(ff, fa).map { case (f, a) => f(a) }
-      override def product[A, B](fa: Reference[A], fb: Reference[B]): Reference[(A, B)] = Reference.Product(fa, fb)
-    }
-
-    private[datas] val compileReference: Reference ~> CompiledReference = λ[Reference ~> CompiledReference] {
-      case Reference.Single(data, getType) =>
-        val tf = ReferenceData.compileData(getType)(data)
-        CompiledReference(tf.fragment, tf.get.asLeft)
-
-      case r: Reference.Optional[a] =>
-        compileReference(r.underlying).ermap {
-          case Left(get)   => Read.fromGetOption(get).asRight
-          case Right(read) => read.map(_.some).asRight
-        }
-
-      case m: Reference.Map[a, b] => compileReference(m.underlying).mapBoth(m.f)
-
-      case p: Reference.Product[a, b] =>
-        def toRead[A]: Either[Get[A], Read[A]] => Read[A] = _.fold(Read.fromGet(_), identity)
-
-        val (leftFrag, leftRead) = compileReference(p.left).rmap(toRead)
-        val (rightFrag, rightRead) = compileReference(p.right).rmap(toRead)
-
-        implicit val lR = leftRead
-        implicit val rR = rightRead
-
-        val _ = (lR, rR) //making scalac happy
-
-        CompiledReference(leftFrag ++ fr", " ++ rightFrag, Read[(a, b)].asRight)
-    }
-  }
-
-  final case class Query[A[_[_]], Queried](
-    base: TableQuery[A],
-    selection: A[Reference] => Reference[Queried],
-    filters: Chain[A[Reference] => Reference[Boolean]]
-  ) {
-
-    def where(filter: A[Reference] => Reference[Boolean]): Query[A, Queried] =
-      copy(filters = filters.append(filter))
-
-    def compileSql: Query0[Queried] = {
-      val (compiledQueryBase, compiledReference) = TableQuery.compileQuery[A, State[Int, *]].apply(base).runA(0).value
-
-      val compiledSelection = selection(compiledReference).compile
-
-      val frag = fr"select" ++ compiledSelection.frag ++
-        fr"from" ++ compiledQueryBase ++
-        Fragments.whereAnd(
-          filters.map(_.apply(compiledReference).compile.frag).toList: _*
+  /**
+    * Returns: the compiled query base (from + joins) and the scoped references underlying it (passed later to selections and filters).
+    */
+  def compileQuery[A[_[_]], F[_]: IndexState: FlatMap]: TableQuery[A] => F[(Fragment, A[Reference])] = {
+    case t: FromTable[A] =>
+      implicit val functorK: FunctorK[A] = t.traverseK
+      IndexState.getAndInc[F].map { index =>
+        val scope = t.table.name + "_x" + index
+        (
+          t.table.identifierFragment ++ Fragment.const(scope),
+          t.lifted.mapK(setScope(scope))
         )
+      }
 
-      implicit val read: Read[Queried] = compiledSelection.readOrGet.fold(Read.fromGet(_), identity)
+    case j: Join[a, b, k] =>
+      import j._
+      (compileQuery[a, F].apply(left), compileQuery[b, F].apply(right)).mapN {
+        case ((leftFrag, leftCompiledReference), (rightFrag, rightCompiledReference)) =>
+          val thisJoinClause = onClause(leftCompiledReference, rightCompiledReference).compile.frag
 
-      frag.query[Queried]
+          val joinFrag = leftFrag ++ Fragment.const(kind.kind) ++ rightFrag ++ fr"on" ++ thisJoinClause
+
+          (joinFrag, kind.buildJoined(leftCompiledReference, rightCompiledReference))
+      }
+  }
+
+}
+
+trait JoinKind[A[_[_]], B[_[_]], Joined[_[_]]] {
+  final type Out[F[_]] = Joined[F]
+
+  def buildJoined(a: A[Reference], b: B[Reference]): Joined[Reference]
+  def kind: String
+}
+
+object JoinKind {
+  type Inner[A[_[_]], B[_[_]]] = JoinKind[A, B, Tuple2KK[A, B, ?[_]]]
+  type Left[A[_[_]], B[_[_]]] = JoinKind[A, B, Tuple2KK[A, OptionTK[B, ?[_]], ?[_]]]
+
+  def left[A[_[_]], B[_[_]]: FunctorK]: Left[A, B] = make("left join")((a, b) => Tuple2KK(a, OptionTK.liftK(b)(Reference.liftOptionK)))
+  def inner[A[_[_]], B[_[_]]]: Inner[A, B] = make("inner join")(Tuple2KK.apply _)
+
+  private def make[A[_[_]], B[_[_]], Joined[_[_]]](
+    name: String
+  )(
+    build: (A[Reference], B[Reference]) => Joined[Reference]
+  ): JoinKind[A, B, Joined] = new JoinKind[A, B, Joined] {
+    def buildJoined(a: A[Reference], b: B[Reference]): Joined[Reference] = build(a, b)
+    val kind: String = name
+  }
+}
+
+final case class Column(name: String) extends AnyVal {
+  def showQuoted: String = "\"" + name + "\""
+}
+
+sealed trait ReferenceData[Type] extends Product with Serializable
+
+object ReferenceData {
+  final case class Column[A](col: datas.Column, scope: Option[String]) extends ReferenceData[A]
+  final case class Lift[Type](value: Type, into: Param[Type HCons HNil]) extends ReferenceData[Type]
+  final case class Raw[Type](fragment: Fragment) extends ReferenceData[Type]
+
+  private[datas] def compileData[Type](getType: Get[Type]): ReferenceData[Type] => TypedFragment[Type] = {
+    case ReferenceData.Column(column, scope) =>
+      val scopeString = scope.foldMap(_ + ".")
+      TypedFragment(Fragment.const(scopeString + column.showQuoted), getType)
+
+    case l: ReferenceData.Lift[a] =>
+      implicit val param: Param[a HCons HNil] = l.into
+      val _ = param //to make scalac happy
+      TypedFragment(fr"${l.value}", getType)
+
+    case r: ReferenceData.Raw[a] => TypedFragment(r.fragment, getType)
+  }
+
+  final case class TypedFragment[Type](fragment: Fragment, get: Get[Type])
+}
+
+sealed trait Reference[Type] extends Product with Serializable {
+
+  private[datas] def compile: CompiledReference[Type] =
+    Reference.compileReference(this)
+}
+
+object Reference {
+  final case class Optional[Type](underlying: Reference[Type]) extends Reference[Option[Type]]
+  final case class Single[Type](data: ReferenceData[Type], getType: Get[Type]) extends Reference[Type]
+  final case class Product[L, R](left: Reference[L], right: Reference[R]) extends Reference[(L, R)]
+  final case class Map[A, B](underlying: Reference[A], f: A => B) extends Reference[B]
+
+  val liftOptionK: Reference ~> OptionT[Reference, ?] = λ[Reference ~> OptionT[Reference, ?]](r => OptionT(Optional(r)))
+
+  def liftOption[Type](reference: Reference[Type]): Reference[Option[Type]] = liftOptionK(reference).value
+
+  def lift[Type: Get](value: Type)(implicit param: Param[Type HCons HNil]): Reference[Type] =
+    Reference.Single[Type](ReferenceData.Lift(value, param), Get[Type])
+
+  def mapData(fk: ReferenceData ~> ReferenceData): Reference ~> Reference =
+    λ[Reference ~> Reference] {
+      case Single(data, getType) => Single(fk(data), getType)
+      case Optional(underlying)  => Optional(mapData(fk)(underlying))
+      case Map(underlying, f)    => Map(mapData(fk)(underlying), f)
+      case Product(left, right)  => Product(mapData(fk)(left), mapData(fk)(right))
     }
+
+  implicit val apply: Apply[Reference] = new Apply[Reference] {
+    override def map[A, B](fa: Reference[A])(f: A => B): Reference[B] = Map(fa, f)
+    override def ap[A, B](ff: Reference[A => B])(fa: Reference[A]): Reference[B] = product(ff, fa).map { case (f, a) => f(a) }
+    override def product[A, B](fa: Reference[A], fb: Reference[B]): Reference[(A, B)] = Reference.Product(fa, fb)
   }
 
-  private[datas] final case class CompiledReference[Type](frag: Fragment, readOrGet: Either[Get[Type], Read[Type]]) {
-    def rmap[T2](f: Either[Get[Type], Read[Type]] => T2): (Fragment, T2) = (frag, f(readOrGet))
+  private[datas] val compileReference: Reference ~> CompiledReference = λ[Reference ~> CompiledReference] {
+    case Reference.Single(data, getType) =>
+      val tf = ReferenceData.compileData(getType)(data)
+      CompiledReference(tf.fragment, tf.get.asLeft)
 
-    def ermap[T2](f: Either[Get[Type], Read[Type]] => Either[Get[T2], Read[T2]]): CompiledReference[T2] =
-      CompiledReference(frag, f(readOrGet))
+    case r: Reference.Optional[a] =>
+      compileReference(r.underlying).ermap {
+        case Left(get)   => Read.fromGetOption(get).asRight
+        case Right(read) => read.map(_.some).asRight
+      }
 
-    def mapBoth[T2](f: Type => T2): CompiledReference[T2] = ermap(_.bimap(_.map(f), _.map(f)))
+    case m: Reference.Map[a, b] => compileReference(m.underlying).mapBoth(m.f)
+
+    case p: Reference.Product[a, b] =>
+      def toRead[A]: Either[Get[A], Read[A]] => Read[A] = _.fold(Read.fromGet(_), identity)
+
+      val (leftFrag, leftRead) = compileReference(p.left).rmap(toRead)
+      val (rightFrag, rightRead) = compileReference(p.right).rmap(toRead)
+
+      implicit val lR = leftRead
+      implicit val rR = rightRead
+
+      val _ = (lR, rR) //making scalac happy
+
+      CompiledReference(leftFrag ++ fr", " ++ rightFrag, Read[(a, b)].asRight)
   }
+}
 
-  //A ((*->*)->*)->* (or so)-kinded option transformer
-  case class OptionTK[F[_[_]], G[_]](underlying: F[OptionT[G, ?]])
+final case class Query[A[_[_]], Queried](
+  base: TableQuery[A],
+  selection: A[Reference] => Reference[Queried],
+  filters: Chain[A[Reference] => Reference[Boolean]]
+) {
 
-  object OptionTK {
-    def liftK[F[_[_]]: FunctorK, G[_]](fg: F[G])(lift: G ~> OptionT[G, ?]): OptionTK[F, G] = OptionTK(fg.mapK(lift))
+  def where(filter: A[Reference] => Reference[Boolean]): Query[A, Queried] =
+    copy(filters = filters.append(filter))
+
+  def compileSql: Query0[Queried] = {
+    val (compiledQueryBase, compiledReference) = TableQuery.compileQuery[A, State[Int, *]].apply(base).runA(0).value
+
+    val compiledSelection = selection(compiledReference).compile
+
+    val frag = fr"select" ++ compiledSelection.frag ++
+      fr"from" ++ compiledQueryBase ++
+      Fragments.whereAnd(
+        filters.map(_.apply(compiledReference).compile.frag).toList: _*
+      )
+
+    implicit val read: Read[Queried] = compiledSelection.readOrGet.fold(Read.fromGet(_), identity)
+
+    frag.query[Queried]
   }
+}
 
-  //A tuple2 of even-higher-kinded types.
-  final case class Tuple2KK[A[_[_]], B[_[_]], F[_]](left: A[F], right: B[F]) {
-    def asTuple: (A[F], B[F]) = (left, right)
-  }
+private[datas] final case class CompiledReference[Type](frag: Fragment, readOrGet: Either[Get[Type], Read[Type]]) {
+  def rmap[T2](f: Either[Get[Type], Read[Type]] => T2): (Fragment, T2) = (frag, f(readOrGet))
+
+  def ermap[T2](f: Either[Get[Type], Read[Type]] => Either[Get[T2], Read[T2]]): CompiledReference[T2] =
+    CompiledReference(frag, f(readOrGet))
+
+  def mapBoth[T2](f: Type => T2): CompiledReference[T2] = ermap(_.bimap(_.map(f), _.map(f)))
+}
+
+object ops {
 
   def over[Type]: (Reference[Type], Reference[Type]) => Reference[Boolean] =
     binary(_ ++ fr">" ++ _)

--- a/core/src/main/scala/datas.scala
+++ b/core/src/main/scala/datas.scala
@@ -18,7 +18,7 @@ import cats.data.OptionT
 object datas {
 
   trait SequenceK[Alg[_[_]]] {
-    def sequence[F[_]: Apply, G[_]](alg: Alg[λ[a => F[G[a]]]]): F[Alg[G]]
+    def sequenceK[F[_]: Apply, G[_]](alg: Alg[λ[a => F[G[a]]]]): F[Alg[G]]
   }
 
   //todo naming
@@ -52,9 +52,9 @@ object datas {
 
     def caseClassSchema[F[_[_]]: FunctorK: SequenceK](name: TableName, stClass: F[ColumnK]): TableQuery[F] =
       implicitly[SequenceK[F]]
-        .sequence(stClass.mapK(columnToStRef))
+        .sequenceK(stClass.mapK(columnToStRef))
         .runA(Chain.empty)
-        .map(w => TableQuery.FromTable(name, w, FunctorK[F], implicitly[SequenceK[F]].sequence[Reference, cats.Id]))
+        .map(w => TableQuery.FromTable(name, w, FunctorK[F], implicitly[SequenceK[F]].sequenceK[Reference, cats.Id]))
         .value
   }
 

--- a/core/src/main/scala/datas/package.scala
+++ b/core/src/main/scala/datas/package.scala
@@ -1,0 +1,26 @@
+import cats.~>
+import cats.mtl.MonadState
+import cats.Apply
+import cats.implicits._
+
+package object datas {
+
+  private[datas] type IndexState[F[_]] = MonadState[F, Int]
+
+  private[datas] object IndexState {
+    def apply[F[_]](implicit F: IndexState[F]): IndexState[F] = F
+    def getAndInc[F[_]: IndexState: Apply]: F[Int] = IndexState[F].get <* IndexState[F].modify(_ + 1)
+  }
+
+  private[datas] def setScope(scope: String): Reference ~> Reference = Reference.mapData {
+    λ[ReferenceData ~> ReferenceData] {
+      case ReferenceData.Column(n, None) =>
+        ReferenceData.Column(n, Some(scope))
+      case c @ ReferenceData.Column(_, Some(_)) =>
+        //todo this case is impossible, we should have that in the types
+        //or else inline it with the catch-all below
+        c
+      case c => c
+    }
+  }
+}

--- a/core/src/main/scala/datas/tagless.scala
+++ b/core/src/main/scala/datas/tagless.scala
@@ -1,0 +1,39 @@
+package datas
+
+import cats.tagless.FunctorK
+import cats.Apply
+import cats.arrow.FunctionK
+import cats.~>
+import cats.data.OptionT
+import cats.tagless.implicits._
+
+object tagless {
+
+  trait TraverseK[Alg[_[_]]] extends FunctorK[Alg] {
+
+    def traverseK[F[_], G[_]: Apply, H[_]](alg: Alg[F])(fk: F ~> λ[a => G[H[a]]]): G[Alg[H]]
+
+    def sequenceK[F[_]: Apply, G[_]](alg: Alg[λ[a => F[G[a]]]]): F[Alg[G]] =
+      traverseK[λ[a => F[G[a]]], F, G](alg)(FunctionK.id[λ[a => F[G[a]]]])
+
+    def mapK[F[_], G[_]](af: Alg[F])(fk: F ~> G): Alg[G] = traverseK[F, cats.Id, G](af)(fk)
+
+    def sequenceKId[F[_]: Apply](alg: Alg[F]): F[Alg[cats.Id]] = sequenceK[F, cats.Id](alg)
+  }
+
+  object TraverseK {
+    def apply[Alg[_[_]]](implicit S: TraverseK[Alg]): TraverseK[Alg] = S
+  }
+
+//A ((*->*)->*)->* (or so)-kinded option transformer
+  case class OptionTK[F[_[_]], G[_]](underlying: F[OptionT[G, ?]])
+
+  object OptionTK {
+    def liftK[F[_[_]]: FunctorK, G[_]](fg: F[G])(lift: G ~> OptionT[G, ?]): OptionTK[F, G] = OptionTK(fg.mapK(lift))
+  }
+
+//A tuple2 of even-higher-kinded types.
+  final case class Tuple2KK[A[_[_]], B[_[_]], F[_]](left: A[F], right: B[F]) {
+    def asTuple: (A[F], B[F]) = (left, right)
+  }
+}

--- a/tests/src/main/scala/BasicQueryTests.scala
+++ b/tests/src/main/scala/BasicQueryTests.scala
@@ -157,6 +157,11 @@ final class BasicJoinQueryTests(implicit xa: Transactor[IO]) {
         expectAllToBe(q)(
           List((true, Some(5L), false), (true, Some(5L), false), (true, Some(5L), false)): _*
         )
+      },
+      test("select all from user") {
+        val q = userSchema.selectAll.where(u => equal(u.name, Reference.lift("Jon")))
+
+        expectAllToBe(q)(User[cats.Id](1L, "Jon", 36))
       }
     )
 
@@ -324,11 +329,6 @@ final class BasicJoinQueryTests(implicit xa: Transactor[IO]) {
         ("John", "Book 2".some),
         ("Jon", none)
       )
-    },
-    test("select all from user") {
-      val q = userSchema.selectAll.where(u => equal(u.name, Reference.lift("Jon")))
-
-      expectAllToBe(q)(User[cats.Id](1L, "Jon", 36))
     }
   )
 

--- a/tests/src/main/scala/BasicQueryTests.scala
+++ b/tests/src/main/scala/BasicQueryTests.scala
@@ -12,7 +12,10 @@ import com.softwaremill.diffx.Diff
 import flawless.data.Suite
 import flawless.data.Assertion
 import cats.Apply
-import datas.TraverseK
+import datas.tagless.TraverseK
+import datas.Query
+import datas.TableName
+import datas.Reference
 
 final class BasicJoinQueryTests(implicit xa: Transactor[IO]) {
 
@@ -34,7 +37,7 @@ final class BasicJoinQueryTests(implicit xa: Transactor[IO]) {
     case (a, b, c, d, e, f, g, h, i) => show"($a, $b, $c, $d, $e, $f, $g, $h, $i)"
   }
 
-  import datas._
+  import datas.ops._
 
   def run: Suite[IO] =
     suite("BasicQueryTests") {
@@ -360,6 +363,8 @@ final class BasicJoinQueryTests(implicit xa: Transactor[IO]) {
   }
 
   import datas.schemas._
+
+  import datas.TableQuery
 
   val userSchema: TableQuery[User] =
     caseClassSchema(

--- a/tests/src/main/scala/BasicQueryTests.scala
+++ b/tests/src/main/scala/BasicQueryTests.scala
@@ -368,27 +368,19 @@ final class BasicJoinQueryTests(implicit xa: Transactor[IO]) {
   val userSchema: TableQuery[User] =
     caseClassSchema(
       TableName("users"),
-      User
-        .sequenceK
-        .sequence[ST, Reference](
-          User[λ[a => ST[Reference[a]]]](column[Long]("id"), column[String]("name"), column[Int]("age"))
-        )
-    )(User.sequenceK.sequence[Reference, cats.Id](_))
+      User[STRef](column[Long]("id"), column[String]("name"), column[Int]("age"))
+    )
 
   val bookSchema: TableQuery[Book] =
     caseClassSchema(
       TableName("books"),
-      Book
-        .sequenceK
-        .sequence[ST, Reference](
-          Book[λ[a => ST[Reference[a]]]](
-            column[Long]("id"),
-            column[Long]("user_id"),
-            column[Long]("parent_id").map(Reference.liftOption),
-            column[String]("name")
-          )
-        )
-    )(Book.sequenceK.sequence[Reference, cats.Id](_))
+      Book[STRef](
+        column[Long]("id"),
+        column[Long]("user_id"),
+        column[Long]("parent_id").map(Reference.liftOption),
+        column[String]("name")
+      )
+    )
 }
 
 final case class User[F[_]](id: F[Long], name: F[String], age: F[Int])

--- a/tests/src/main/scala/BasicQueryTests.scala
+++ b/tests/src/main/scala/BasicQueryTests.scala
@@ -162,7 +162,7 @@ final class BasicJoinQueryTests(implicit xa: Transactor[IO]) {
         val q = userSchema.selectAll.where(u => equal(u.name, Reference.lift("Jon")))
 
         expectAllToBe(q)(User[cats.Id](1L, "Jon", 36))
-      }
+      },
     )
 
   def innerJoinTests = tests(

--- a/tests/src/main/scala/BasicQueryTests.scala
+++ b/tests/src/main/scala/BasicQueryTests.scala
@@ -388,7 +388,7 @@ object User {
   }
 
   implicit val sequenceK: SequenceK[User] = new SequenceK[User] {
-    def sequence[F[_]: Apply, G[_]](alg: User[λ[a => F[G[a]]]]): F[User[G]] = (alg.id, alg.name, alg.age).mapN(User[G])
+    def sequenceK[F[_]: Apply, G[_]](alg: User[λ[a => F[G[a]]]]): F[User[G]] = (alg.id, alg.name, alg.age).mapN(User[G])
   }
 
   implicit val showId: Show[User[cats.Id]] = Show.fromToString
@@ -404,6 +404,6 @@ object Book {
   }
 
   implicit val sequenceK: SequenceK[Book] = new SequenceK[Book] {
-    def sequence[F[_]: Apply, G[_]](alg: Book[λ[a => F[G[a]]]]): F[Book[G]] = (alg.id, alg.userId, alg.parentId, alg.name).mapN(Book[G])
+    def sequenceK[F[_]: Apply, G[_]](alg: Book[λ[a => F[G[a]]]]): F[Book[G]] = (alg.id, alg.userId, alg.parentId, alg.name).mapN(Book[G])
   }
 }

--- a/tests/src/main/scala/BasicQueryTests.scala
+++ b/tests/src/main/scala/BasicQueryTests.scala
@@ -12,11 +12,8 @@ import cats.data.NonEmptyList
 import com.softwaremill.diffx.Diff
 import flawless.data.Suite
 import flawless.data.Assertion
-import cats.Applicative
-import cats.Monad
 import cats.Apply
 import datas.SequenceK
-import cats.data.Nested
 
 final class BasicJoinQueryTests(implicit xa: Transactor[IO]) {
 
@@ -368,16 +365,16 @@ final class BasicJoinQueryTests(implicit xa: Transactor[IO]) {
   val userSchema: TableQuery[User] =
     caseClassSchema(
       TableName("users"),
-      User[STRef](column[Long]("id"), column[String]("name"), column[Int]("age"))
+      User(column[Long]("id"), column[String]("name"), column[Int]("age"))
     )
 
   val bookSchema: TableQuery[Book] =
     caseClassSchema(
       TableName("books"),
-      Book[STRef](
+      Book(
         column[Long]("id"),
         column[Long]("user_id"),
-        column[Long]("parent_id").map(Reference.liftOption),
+        column[Long]("parent_id").optional,
         column[String]("name")
       )
     )


### PR DESCRIPTION
This adds basic selectAll support to single-table TableQueries.

Also closes #12 by providing a new abstraction for columns (and optionality thereof) only, as well as removing the State monad from the public API.

Adding `TraverseK` as a new type class (that might end up in cats-tagless), used for `selectAll` and finding columns from the schema.