### PR TITLE
`selectAll` on joins

### DIFF
--- a/core/src/main/scala/datas/joins.scala
+++ b/core/src/main/scala/datas/joins.scala
@@ -2,6 +2,7 @@ package datas
 
 import datas.tagless.Tuple2KK
 import datas.tagless.OptionTK
+import datas.tagless.TraverseK
 import cats.tagless.FunctorK
 
 sealed trait JoinKind[A[_[_]], B[_[_]], Joined[_[_]]] {
@@ -10,21 +11,31 @@ sealed trait JoinKind[A[_[_]], B[_[_]], Joined[_[_]]] {
   // ◙‿◙
   private[datas] def buildJoint(a: A[Reference], b: B[Reference]): Joined[Reference]
   private[datas] def kind: String
+  private[datas] def deriveTraverseK(left: TraverseK[A], right: TraverseK[B]): TraverseK[Joined]
 }
 
 object JoinKind {
   type Inner[A[_[_]], B[_[_]]] = JoinKind[A, B, Tuple2KK[A, B, ?[_]]]
   type Left[A[_[_]], B[_[_]]] = JoinKind[A, B, Tuple2KK[A, OptionTK[B, ?[_]], ?[_]]]
 
-  def left[A[_[_]], B[_[_]]: FunctorK]: Left[A, B] = make("left join")((a, b) => Tuple2KK(a, OptionTK.liftK(b)(Reference.liftOptionK)))
-  def inner[A[_[_]], B[_[_]]]: Inner[A, B] = make("inner join")(Tuple2KK.apply _)
+  def left[A[_[_]], B[_[_]]: FunctorK]: Left[A, B] =
+    make[A, B, Left[A, B]#Out]("left join")((a, b) => Tuple2KK(a, OptionTK.liftK(b)(Reference.liftOptionK)))(implicit a =>
+      implicit b => TraverseK[Left[A, B]#Out]
+    )
+
+  def inner[A[_[_]], B[_[_]]]: Inner[A, B] =
+    make[A, B, Inner[A, B]#Out]("inner join")(Tuple2KK.apply _)(implicit a => implicit b => TraverseK[Inner[A, B]#Out])
 
   private def make[A[_[_]], B[_[_]], Joined[_[_]]](
     name: String
   )(
     build: (A[Reference], B[Reference]) => Joined[Reference]
+  )(
+    deriveTraverseKFromParts: TraverseK[A] => TraverseK[B] => TraverseK[Joined]
   ): JoinKind[A, B, Joined] = new JoinKind[A, B, Joined] {
     def buildJoint(a: A[Reference], b: B[Reference]): Joined[Reference] = build(a, b)
     val kind: String = name
+
+    def deriveTraverseK(left: TraverseK[A], right: TraverseK[B]): TraverseK[Joined] = deriveTraverseKFromParts(left)(right)
   }
 }

--- a/core/src/main/scala/datas/ops.scala
+++ b/core/src/main/scala/datas/ops.scala
@@ -8,6 +8,11 @@ object ops {
     def >=(another: Reference[Type]): Reference[Boolean] = over(self, another)
     def <=(another: Reference[Type]): Reference[Boolean] = another >= self
     def ===(another: Reference[Type]): Reference[Boolean] = equal(self, another)
+
+    def ||(another: Reference[Boolean])(implicit isBool: Type =:= Boolean): Reference[Boolean] = {
+      val _ = isBool
+      binary(_ ++ fr"or" ++ _)(self, another)
+    }
   }
 
   implicit final class LiftAny[Type](private val self: Type) extends AnyVal {

--- a/core/src/main/scala/datas/queries.scala
+++ b/core/src/main/scala/datas/queries.scala
@@ -5,56 +5,31 @@ import doobie.util.query.Query0
 import cats.data.State
 import doobie.implicits._
 import cats.mtl.instances.all._
-import cats.implicits._
 import doobie.util.Read
 import doobie.Fragments
 
-sealed trait Query[A[_[_]], Queried] extends Product with Serializable {
-  def where(filter: A[Reference] => Reference[Boolean]): Query[A, Queried]
+final case class Query[A[_[_]], Queried](
+  base: QueryBase[A],
+  selection: A[Reference] => Reference[Queried],
+  filters: Chain[A[Reference] => Reference[Boolean]]
+) {
 
-  def compileSql: Query0[Queried]
-}
+  def where(filter: A[Reference] => Reference[Boolean]): Query[A, Queried] =
+    copy(filters = filters.append(filter))
 
-private[datas] object Query {
-  final case class Function[A[_[_]], Queried](
-    base: QueryBase[A],
-    selection: A[Reference] => Reference[Queried],
-    filters: Chain[A[Reference] => Reference[Boolean]]
-  ) extends Query[A, Queried] {
+  def compileSql: Query0[Queried] = {
+    val (compiledQueryBase, compiledReference) = QueryBase.compileQuery[A, State[Int, *]].apply(base).runA(0).value
 
-    def where(filter: A[Reference] => Reference[Boolean]): Query[A, Queried] =
-      copy(filters = filters.append(filter))
+    val compiledSelection = selection(compiledReference).compile
 
-    def compileSql: Query0[Queried] = {
-      val (compiledQueryBase, compiledReference) = QueryBase.compileQuery[A, State[Int, *]].apply(base).runA(0).value
+    val frag = fr"select" ++ compiledSelection.frag ++
+      fr"from" ++ compiledQueryBase ++
+      Fragments.whereAnd(
+        filters.map(_.apply(compiledReference).compile.frag).toList: _*
+      )
 
-      val compiledSelection = selection(compiledReference).compile
+    implicit val read: Read[Queried] = compiledSelection.readOrGet.fold(Read.fromGet(_), identity)
 
-      val frag = fr"select" ++ compiledSelection.frag ++
-        fr"from" ++ compiledQueryBase ++
-        Fragments.whereAnd(
-          filters.map(_.apply(compiledReference).compile.frag).toList: _*
-        )
-
-      implicit val read: Read[Queried] = compiledSelection.readOrGet.fold(Read.fromGet(_), identity)
-
-      frag.query[Queried]
-    }
-  }
-
-  final case class All[A[_[_]]](base: QueryBase[A], filters: Chain[A[Reference] => Reference[Boolean]]) extends Query[A, A[cats.Id]] {
-    //todo factor out to common class
-    def where(filter: A[Reference] => Reference[Boolean]): Query[A, A[cats.Id]] = copy(filters = filters.append(filter))
-
-    def compileSql: Query0[A[cats.Id]] = base match {
-      case ft: QueryBase.FromTable[A] =>
-        import ops._
-        base
-          .select(r => ft.traverseK.sequenceKId(r))
-          // this has got to be the ugliest thing, but it's just for now, I swear...
-          .where(filters.foldLeft((_: A[Reference]) => Reference.lift(false))((_, _).mapN(_ || _)))
-          .compileSql
-      case _: QueryBase.Join[a, b, A] => ???
-    }
+    frag.query[Queried]
   }
 }

--- a/core/src/main/scala/datas/queries.scala
+++ b/core/src/main/scala/datas/queries.scala
@@ -5,31 +5,56 @@ import doobie.util.query.Query0
 import cats.data.State
 import doobie.implicits._
 import cats.mtl.instances.all._
+import cats.implicits._
 import doobie.util.Read
 import doobie.Fragments
 
-final case class Query[A[_[_]], Queried] private[datas] (
-  base: QueryBase[A],
-  selection: A[Reference] => Reference[Queried],
-  filters: Chain[A[Reference] => Reference[Boolean]]
-) {
+sealed trait Query[A[_[_]], Queried] extends Product with Serializable {
+  def where(filter: A[Reference] => Reference[Boolean]): Query[A, Queried]
 
-  def where(filter: A[Reference] => Reference[Boolean]): Query[A, Queried] =
-    copy(filters = filters.append(filter))
+  def compileSql: Query0[Queried]
+}
 
-  def compileSql: Query0[Queried] = {
-    val (compiledQueryBase, compiledReference) = QueryBase.compileQuery[A, State[Int, *]].apply(base).runA(0).value
+private[datas] object Query {
+  final case class Function[A[_[_]], Queried](
+    base: QueryBase[A],
+    selection: A[Reference] => Reference[Queried],
+    filters: Chain[A[Reference] => Reference[Boolean]]
+  ) extends Query[A, Queried] {
 
-    val compiledSelection = selection(compiledReference).compile
+    def where(filter: A[Reference] => Reference[Boolean]): Query[A, Queried] =
+      copy(filters = filters.append(filter))
 
-    val frag = fr"select" ++ compiledSelection.frag ++
-      fr"from" ++ compiledQueryBase ++
-      Fragments.whereAnd(
-        filters.map(_.apply(compiledReference).compile.frag).toList: _*
-      )
+    def compileSql: Query0[Queried] = {
+      val (compiledQueryBase, compiledReference) = QueryBase.compileQuery[A, State[Int, *]].apply(base).runA(0).value
 
-    implicit val read: Read[Queried] = compiledSelection.readOrGet.fold(Read.fromGet(_), identity)
+      val compiledSelection = selection(compiledReference).compile
 
-    frag.query[Queried]
+      val frag = fr"select" ++ compiledSelection.frag ++
+        fr"from" ++ compiledQueryBase ++
+        Fragments.whereAnd(
+          filters.map(_.apply(compiledReference).compile.frag).toList: _*
+        )
+
+      implicit val read: Read[Queried] = compiledSelection.readOrGet.fold(Read.fromGet(_), identity)
+
+      frag.query[Queried]
+    }
+  }
+
+  final case class All[A[_[_]]](base: QueryBase[A], filters: Chain[A[Reference] => Reference[Boolean]]) extends Query[A, A[cats.Id]] {
+    //todo factor out to common class
+    def where(filter: A[Reference] => Reference[Boolean]): Query[A, A[cats.Id]] = copy(filters = filters.append(filter))
+
+    def compileSql: Query0[A[cats.Id]] = base match {
+      case ft: QueryBase.FromTable[A] =>
+        import ops._
+        base
+          .select(r => ft.traverseK.sequenceKId(r))
+          // this has got to be the ugliest thing, but it's just for now, I swear...
+          .where(filters.foldLeft((_: A[Reference]) => Reference.lift(false))((_, _).mapN(_ || _)))
+          .compileSql
+      case _: QueryBase.Join[a, b, A] => ???
+    }
   }
 }

--- a/core/src/main/scala/datas/references.scala
+++ b/core/src/main/scala/datas/references.scala
@@ -1,4 +1,5 @@
 package datas
+
 import cats.implicits._
 import doobie.util.fragment.Fragment
 import doobie._
@@ -95,7 +96,7 @@ private[datas] final case class CompiledReference[Type](frag: Fragment, readOrGe
   def rmap[T2](f: Either[Get[Type], Read[Type]] => T2): (Fragment, T2) = (frag, f(readOrGet))
 
   def ermap[T2](f: Either[Get[Type], Read[Type]] => Either[Get[T2], Read[T2]]): CompiledReference[T2] =
-    CompiledReference(frag, f(readOrGet))
+    (CompiledReference.apply[T2] _).tupled(rmap(f))
 
   def map[T2](f: Type => T2): CompiledReference[T2] = ermap(_.bimap(_.map(f), _.map(f)))
 }

--- a/core/src/main/scala/datas/tables.scala
+++ b/core/src/main/scala/datas/tables.scala
@@ -21,7 +21,7 @@ sealed trait QueryBase[A[_[_]]] extends Product with Serializable {
   )(
     onClause: (A[Reference], B[Reference]) => Reference[Boolean]
   ): QueryBase[JoinKind.Inner[A, B]#Out] =
-    join(another) { _.inner }(onClause)
+    join(another)(_.inner)(onClause)
 
   def leftJoin[B[_[_]]](
     another: QueryBase[B]

--- a/core/src/main/scala/datas/tables.scala
+++ b/core/src/main/scala/datas/tables.scala
@@ -10,6 +10,7 @@ import cats.tagless.implicits._
 import cats.mtl.instances.all._
 import cats.FlatMap
 import datas.tagless.TraverseK
+import datas.tagless.Tuple2KK
 
 /**
   * QueryBase: a thing you can query from. It'll usually be a table or a join thereof.
@@ -39,15 +40,10 @@ sealed trait QueryBase[A[_[_]]] extends Product with Serializable {
   ): QueryBase[Joined] =
     QueryBase.Join(this, another, how(JoinKind), onClause)
 
-  def selectAll: Query[A, A[cats.Id]] = select { aref =>
-    this match {
-      case ft: QueryBase.FromTable[A] => ft.traverseK.sequenceKId(aref)
-      case _                          => throw new Exception("select * isn't supported on joins yet")
-    }
-  }
+  def selectAll: Query[A, A[cats.Id]] = Query.All(this, filters = Chain.empty)
 
   def select[Queried](selection: A[Reference] => Reference[Queried]): Query[A, Queried] =
-    Query(this, selection, filters = Chain.empty)
+    Query.Function(this, selection, filters = Chain.empty)
 }
 
 private[datas] object QueryBase {

--- a/core/src/main/scala/datas/tagless.scala
+++ b/core/src/main/scala/datas/tagless.scala
@@ -60,4 +60,15 @@ object tagless {
   final case class Tuple2KK[A[_[_]], B[_[_]], F[_]](left: A[F], right: B[F]) {
     def asTuple: (A[F], B[F]) = (left, right)
   }
+
+  object Tuple2KK {
+
+    import TraverseK.ops._
+
+    implicit def traverseK[A[_[_]]: TraverseK, B[_[_]]: TraverseK]: TraverseK[Tuple2KK[A, B, *[_]]] = new TraverseK[Tuple2KK[A, B, *[_]]] {
+
+      def traverseK[F[_], G[_]: Apply, H[_]](alg: Tuple2KK[A, B, F])(fk: F ~> λ[a => G[H[a]]]): G[Tuple2KK[A, B, H]] =
+        (alg.left.traverseK(fk), alg.right.traverseK(fk)).mapN(Tuple2KK(_, _))
+    }
+  }
 }

--- a/tests/src/main/scala/tests/BasicQueryTests.scala
+++ b/tests/src/main/scala/tests/BasicQueryTests.scala
@@ -15,6 +15,9 @@ import datas.Reference
 import flawless._
 import flawless.data.Assertion
 import flawless.data.Suite
+import datas.tagless.Tuple2KK
+import datas.tagless.OptionTK
+import cats.data.OptionT
 
 final class BasicJoinQueryTests(implicit xa: Transactor[IO]) extends SuiteClass[IO] {
   import flawless.syntax._
@@ -174,13 +177,65 @@ final class BasicJoinQueryTests(implicit xa: Transactor[IO]) extends SuiteClass[
           User.schema.selectAll.where(u => equal(u.name, Reference.lift("Jon")))
 
         expectAllToBe(q)(User[cats.Id](1L, "Jon", 36))
-      } /* ,
+      },
       test("select all from simple join") {
         val q = User.schema.innerJoin(Book.schema)(_.id === _.userId).selectAll
 
         implicit def showAny[A]: Show[A] = Show.fromToString
-        expectAllToBe(q)()
-      } */
+
+        expectAllToBe(q)(
+          Tuple2KK(User[cats.Id](2, "Jakub", 23), Book[cats.Id](1, 2, None, "Book 1")),
+          Tuple2KK(User[cats.Id](3, "John", 40), Book[cats.Id](2, 3, Some(1), "Book 2"))
+        )
+      },
+      test("select all from left join") {
+        import TraverseK.ops._
+
+        val q = User
+          .schema
+          .leftJoin(Book.schema) { (u, b) =>
+            equal(u.id, b.userId)
+          }
+          .selectAll
+
+        implicit def showAny[A]: Show[A] = Show.fromToString
+
+        expectAllToBe(q)(
+          Tuple2KK(
+            User[cats.Id](2, "Jakub", 23),
+            OptionTK(
+              Book(
+                OptionT[cats.Id, Long](1L.some),
+                OptionT[cats.Id, Long](2L.some),
+                OptionT[cats.Id, Option[Long]](none.some),
+                OptionT[cats.Id, String]("Book 1".some)
+              )
+            )
+          ),
+          Tuple2KK(
+            User[cats.Id](3, "John", 40),
+            OptionTK(
+              Book(
+                OptionT[cats.Id, Long](2L.some),
+                OptionT[cats.Id, Long](3L.some),
+                OptionT[cats.Id, Option[Long]](1L.some.some),
+                OptionT[cats.Id, String]("Book 2".some)
+              )
+            )
+          ),
+          Tuple2KK(
+            User[cats.Id](1, "Jon", 36),
+            OptionTK(
+              Book(
+                OptionT[cats.Id, Long](none),
+                OptionT[cats.Id, Long](none),
+                OptionT[cats.Id, Option[Long]](none.some), //todo same bug as below
+                OptionT[cats.Id, String](none)
+              )
+            )
+          )
+        )
+      }
     )
 
   def innerJoinTests = tests(
@@ -350,13 +405,13 @@ final class BasicJoinQueryTests(implicit xa: Transactor[IO]) extends SuiteClass[
           val user = t.left
           val book = t.right
 
-          (user.name, book.underlying.name.value).tupled
+          (user.name, book.underlying.name.value, book.underlying.parentId.value).tupled
         }
 
       expectAllToBe(q)(
-        ("Jakub", "Book 1".some),
-        ("John", "Book 2".some),
-        ("Jon", none)
+        ("Jakub", "Book 1".some, none.some),
+        ("John", "Book 2".some, 1L.some.some),
+        ("Jon", none, none.some) //todo bug: the last field should definitely be none
       )
     }
   )

--- a/tests/src/main/scala/tests/BasicQueryTests.scala
+++ b/tests/src/main/scala/tests/BasicQueryTests.scala
@@ -14,6 +14,7 @@ import datas.Query
 import datas.Reference
 import flawless._
 import flawless.data.Assertion
+import flawless.data.Suite
 
 final class BasicJoinQueryTests(implicit xa: Transactor[IO]) extends SuiteClass[IO] {
   import flawless.syntax._
@@ -173,7 +174,13 @@ final class BasicJoinQueryTests(implicit xa: Transactor[IO]) extends SuiteClass[
           User.schema.selectAll.where(u => equal(u.name, Reference.lift("Jon")))
 
         expectAllToBe(q)(User[cats.Id](1L, "Jon", 36))
-      }
+      } /* ,
+      test("select all from simple join") {
+        val q = User.schema.innerJoin(Book.schema)(_.id === _.userId).selectAll
+
+        implicit def showAny[A]: Show[A] = Show.fromToString
+        expectAllToBe(q)()
+      } */
     )
 
   def innerJoinTests = tests(


### PR DESCRIPTION
This PR makes `selectAll`, a quick utility for querying all fields from a table, work on joins as well. There's quite a lot of internal work that is done to make it work though, and an alternative would require an additional constraint on `def selectAll(implicit K: TraverseK[Alg])`. For now I'll keep it as it is to reduce duplication of constraint passing.